### PR TITLE
Use a separate process to send data to zipkin instead of timer:apply_…

### DIFF
--- a/src/otter_conn_zipkin.erl
+++ b/src/otter_conn_zipkin.erl
@@ -44,9 +44,7 @@ sup_init() ->
             {otter_zipkin_status,  [{read_concurrency, true}]}
         ]
     ],
-    ets:insert(otter_zipkin_status, {current_buffer, otter_zipkin_buffer1}),
-    SendInterval = otter_config:read(zipkin_batch_interval_ms, 100),
-    timer:apply_interval(SendInterval, ?MODULE, send_buffer, []).
+    ets:insert(otter_zipkin_status, {current_buffer, otter_zipkin_buffer1}).
 
 store_span(Span) ->
     [{_, Buffer}] = ets:lookup(otter_zipkin_status, current_buffer),

--- a/src/otter_sup.erl
+++ b/src/otter_sup.erl
@@ -31,7 +31,7 @@ start_link() ->
 
 init([]) ->
     [M:sup_init() || M <- [otter_lib_snapshot_count, otter_conn_zipkin]],
-    {ok, {{one_for_all, 0, 1}, [
+    {ok, {{one_for_all, 5, 1}, [
         #{id => otter_zipkin_sender, start => {otter_zipkin_sender, start_link, []}}
     ]}}.
 

--- a/src/otter_sup.erl
+++ b/src/otter_sup.erl
@@ -32,7 +32,12 @@ start_link() ->
 init([]) ->
     [M:sup_init() || M <- [otter_lib_snapshot_count, otter_conn_zipkin]],
     {ok, {{one_for_all, 5, 1}, [
-        #{id => otter_zipkin_sender, start => {otter_zipkin_sender, start_link, []}}
-    ]}}.
+                                {otter_zipkin_sender, 
+                                 {otter_zipkin_sender, start_link, []},
+                                 permanent,
+                                 5000,
+                                 worker,
+                                 [otter_zipkin_sender]}
+                               ]}}.
 
 

--- a/src/otter_zipkin_sender.erl
+++ b/src/otter_zipkin_sender.erl
@@ -34,7 +34,7 @@
         ]).
 
 -define(SERVER, ?MODULE).
--define(DEFAULT_BATCH_INTERVAL, 5000).
+-define(DEFAULT_BATCH_INTERVAL, 1000).
 
 -record(state, {}).
 

--- a/src/otter_zipkin_sender.erl
+++ b/src/otter_zipkin_sender.erl
@@ -34,6 +34,7 @@
         ]).
 
 -define(SERVER, ?MODULE).
+-define(DEFAULT_BATCH_INTERVAL, 5000).
 
 -record(state, {}).
 
@@ -63,5 +64,4 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 terminate(_Reason, _State) -> ok.
 
 get_time() ->
-    {ok, Time} = application:get_env(zipkin_batch_interval_ms),
-    Time.
+    application:get_env(otter, zipkin_batch_interval_ms, ?DEFAULT_BATCH_INTERVAL).


### PR DESCRIPTION
…interval.

Using timer:apply_interval results in a large number of processes
simultaneously sending data if the zipkin server cannot respond to
requests quickly enough.